### PR TITLE
fixed issue #4

### DIFF
--- a/src/cable.js
+++ b/src/cable.js
@@ -101,7 +101,8 @@ export default class Cable {
 	 * @param {string} channelName - The name of the Action Cable server channel / The custom name chosen for the component channel
 	 */
 	unsubscribe(channelName) {
-		this._removeChannel(channelName);
+		if (this._channels.subscriptions[channelName])
+			this._channels.subscriptions[channelName].unsubscribe();
 	}
 
 	/**

--- a/tests/cable.spec.js
+++ b/tests/cable.spec.js
@@ -230,13 +230,32 @@ describe('Cable', () => {
 		global._contexts[channelUid] = { users: 1 };
 
 		cable.unsubscribe.call(global, channelName);
+		expect(global._channels[channelName]).toBeDefined();
+		expect(global._channels.subscriptions[channelName]).toBeDefined();
+		expect(global._contexts[channelUid]).toBeDefined();
+		expect(unsubscribe).toBeCalledTimes(1);
+	});
+
+	test('It should remove channel correctly when component is destroyed', () => {
+		const unsubscribe = jest.fn();
+		const channelName = 'ChatChannel';
+		const channelUid = 3;
+
+		global._channels.ChatChannel = {
+			_uid: channelUid,
+			name: channelName
+		};
+		global._channels.subscriptions[channelName] = { unsubscribe };
+		global._contexts[channelUid] = { users: 1 };
+
+		cable._removeChannel.call(global, channelName);
 		expect(global._channels[channelName]).toBeUndefined();
 		expect(global._channels.subscriptions[channelName]).toBeUndefined();
 		expect(global._contexts[channelUid]).toBeUndefined();
 		expect(unsubscribe).toBeCalledTimes(1);
 	});
 
-	test('It should not remove context when unsubscribing from channel if users still exist', () => {
+	test('It should not remove context when removing channel if users still exist', () => {
 		const unsubscribe = jest.fn();
 		const channelName = 'ChatChannel';
 		const channelUid = 3;
@@ -248,7 +267,7 @@ describe('Cable', () => {
 		global._channels.subscriptions[channelName] = { unsubscribe };
 		global._contexts[channelUid] = { users: 2 };
 
-		cable.unsubscribe.call(global, channelName);
+		cable._removeChannel.call(global, channelName);
 		expect(global._channels[channelName]).toBeUndefined();
 		expect(global._channels.subscriptions[channelName]).toBeUndefined();
 		expect(global._contexts[channelUid]).toBeDefined();


### PR DESCRIPTION
Fixes issue #4 by **only** unsubscribing from the ActionCable channel when `this.$cable.unsubscribe` is called. Removing a channel and subsequently unsubscribing should only happen when a component is destroyed.