### PR TITLE
Respect default ActionCable behaviour for missing `connectionUrl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ new Vue({
 | ------------------ | -------- | ----------- | ------------ | ---------------------------------------------------------------------------------------------------------- |
 | debug              | Boolean  | `false`     | Optional     | Enable logging for debug                                                                                   |
 | debugLevel         | String   | `error`     | Optional     | Debug level required for logging. Either `info`, `error`, or `all`                                         |
-| connectionUrl      | String/Function   | `null`      | Required     | ActionCable websocket server url                                                                           |
+| connectionUrl      | String/Function   | `null`      | Optional     | ActionCable websocket server url. Omit it for the [default behavior](https://guides.rubyonrails.org/action_cable_overview.html#connect-consumer) |
 | connectImmediately | Boolean  | `true`      | Optional     | ActionCable connects to your server immediately. If false, ActionCable connects on the first subscription. |
 
 

--- a/src/cable.js
+++ b/src/cable.js
@@ -13,7 +13,7 @@ export default class Cable {
    * ActionCableVue $cable entry point
    * @param {Object} Vue
    * @param {Object} options - ActionCableVue options
-   * @param {string} options.connectionUrl - ActionCable server websocket URL
+   * @param {string|Function|null} [options.connectionUrl=null] - ActionCable server websocket URL
    * @param {boolean} options.debug - Enable logging for debug
    * @param {string} options.debugLevel - Debug level required for logging. Either `info`, `error`, or `all`
    * @param {boolean} options.connectImmediately - Connect immediately or wait until the first subscription.
@@ -161,17 +161,13 @@ export default class Cable {
 
   /**
    * Connects to an Action Cable server
-   * @param {string} url - The websocket URL of the Action Cable server.
+   * @param {string|Function|null} url - The websocket URL of the Action Cable server.
    */
   _connect(url) {
-    if (typeof url == "string") {
-      this._cable = createConsumer(url);
-    } else if (typeof url == "function") {
+    if (typeof url == "function") {
       this._cable = createConsumer(url());
     } else {
-      throw new Error(
-        "Connection URL needs to be a valid Action Cable websocket server URL."
-      );
+      this._cable = createConsumer(url);
     }
   }
 
@@ -179,7 +175,7 @@ export default class Cable {
     this.connection = {
       /**
        * Manually connect to an Action Cable server. Automatically re-subscribes all your subscriptions.
-       * @param {String|Function} url - Optional parameter. The connection URL to your Action Cable server
+       * @param {String|Function|null} [url=null] - Optional parameter. The connection URL to your Action Cable server
        */
       connect: (url = null) => {
         if (this._cable) {

--- a/tests/cable.spec.js
+++ b/tests/cable.spec.js
@@ -45,12 +45,14 @@ describe("Cable", () => {
     expect(cable.connection).toBeDefined();
   });
 
-  test("It should throw error if options not provided", () => {
-    const fn = () => {
-      cable = new Cable(Vue);
-    };
+  test("It should initialize correctly if options not provided", () => {
+    cable = new Cable(Vue);
 
-    expect(fn).toThrowError();
+    expect(Vue.prototype.$cable._cable).toBeDefined();
+    expect(Vue.mixin).toHaveBeenCalled();
+    expect(cable._logger._debug).toBe(false);
+    expect(cable._logger._debugLevel).toBe("error");
+    expect(cable.connection).toBeDefined();
   });
 
   test("It should not connect immediately if connectImmediately is false", () => {
@@ -80,14 +82,6 @@ describe("Cable", () => {
     cable.subscribe.call(global, { channel: "ChatChannel" });
     expect(global._connect).toHaveBeenCalled();
     expect(global.subscribe).toHaveBeenCalled();
-  });
-
-  test("It should not connect if param is not a string or function", () => {
-    const fn = () => {
-      cable._connect({});
-    };
-
-    expect(fn).toThrowError();
   });
 
   test("It should correctly subscribe to channel", () => {


### PR DESCRIPTION
`createConsumer` accepts [optional URL](https://github.com/rails/rails/blob/d03177ffbccb5b30217448d526f1e9aa1fa24297/actioncable/app/javascript/action_cable/index.js#L22-L24) to WebSocket. Otherwise, it tries to read  `action_cable_meta_tag` in HTML layout HEAD or falls back to the default `/cable`. This change makes the library to respect this behavior naturally. 

Previously, it was possible only by passing `() => null` function to `connectionUrl` option only.