### PR TITLE
fix build error for typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,14 +36,14 @@
 	},
 	"homepage": "https://github.com/mclintprojects/actioncable-vue#readme",
 	"dependencies": {
-		"@rails/actioncable": "^6.0.2"
+		"@rails/actioncable": "^6.0.2",
+		"@types/actioncable": "^5.2.3"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.1.2",
 		"@babel/plugin-proposal-class-properties": "^7.1.0",
 		"@babel/plugin-transform-classes": "^7.1.0",
 		"@babel/preset-env": "^7.1.0",
-		"@types/actioncable": "^5.2.3",
 		"@vue/test-utils": "^1.0.0-beta.28",
 		"babel-core": "^7.0.0-bridge.0",
 		"babel-jest": "^25.1.0",


### PR DESCRIPTION
We had issues testing this locally before submitting the last PR. Seems we need the actioncable types in dependencies instead of dev dependencies